### PR TITLE
Add path field in last log using multiline mode.

### DIFF
--- a/test/plugin/in_tail_path.rb
+++ b/test/plugin/in_tail_path.rb
@@ -49,4 +49,36 @@ class TailPathInputTest < Test::Unit::TestCase
     assert_equal({"message"=>"test1", "foobar"=>"#{TMP_DIR}/tail.txt"}, emits[0][2])
     assert_equal({"message"=>"test2", "foobar"=>"#{TMP_DIR}/tail.txt"}, emits[1][2])
   end
+
+  def test_path_key_multiline
+    File.open("#{TMP_DIR}/tail2.txt", "w") { |f| }
+
+    d = create_driver(%{
+       path #{TMP_DIR}/tail2.txt
+       tag t2
+       format multiline
+       format_firstline /\\[/
+       format1 /\\[(?<message>.*)\\]/
+       path_key foobar
+    }, false)
+
+    d.run do
+      sleep 1
+
+      File.open("#{TMP_DIR}/tail2.txt", "a") {|f|
+        f.puts "[test1-1,"
+        f.puts "test1-2,"
+        f.puts "test1-3]"
+        f.puts "[test2-1,"
+        f.puts "test2-2,"
+        f.puts "test2-3]"
+      }
+      sleep 1
+    end
+
+    emits = d.emits
+    assert_equal(true, emits.length > 0)
+    assert_equal({"message" => "test1-1,\ntest1-2,\ntest1-3", "foobar" => "#{TMP_DIR}/tail2.txt"}, emits[0][2])
+    assert_equal({"message" => "test2-1,\ntest2-2,\ntest2-3", "foobar" => "#{TMP_DIR}/tail2.txt"}, emits[1][2])
+  end
 end


### PR DESCRIPTION
When using multiline mode, a last log has no path field.

This reason is that the method 'flush_buffer' is not overrided to add path field.
