### PR TITLE
Specify dependent Fluentd version

### DIFF
--- a/fluent-plugin-tail_path.gemspec
+++ b/fluent-plugin-tail_path.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency "fluentd", ">= 0.10.58"
+  s.add_runtime_dependency "fluentd", [">= 0.10.58", "< 0.14.0"]
   s.add_development_dependency "rake"
   s.add_development_dependency "test-unit"
 end


### PR DESCRIPTION
We should specify dependent Fluentd version explicitly.

Because Fluentd v0.14 includes this feature. see:
https://github.com/fluent/fluentd/pull/951

Could you check this?